### PR TITLE
Add Typescript and a simple tsconfig.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "jest-cli": "^28.1.3",
         "nodemon": "^2.0.22",
         "rimraf": "^5.0.0",
+        "typescript": "^5.5.2",
         "yuidocjs": "^0.10.2"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+
+    /* Modules */
+    "module": "ESNext",                                /* Specify what module code is generated. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+
+    /* JavaScript Support */
+    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+
+    /* Emit */
+    "noEmit": true,                                   /* Disable emitting files from a compilation. */
+
+    /* Interop Constraints */
+    "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": false,                                      /* Enable all strict type-checking options. */
+
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
Gives a lot of errors when run (more if we turn `strict` on)

Only intended to allow for type checking first. Can move to building with it incrementally.